### PR TITLE
Add Discord user to game when created

### DIFF
--- a/prisma/migrations/20240907010447_add_created_by_to_games/migration.sql
+++ b/prisma/migrations/20240907010447_add_created_by_to_games/migration.sql
@@ -1,0 +1,25 @@
+/*
+  Warnings:
+
+  - Added the required column `created_by_id` to the `games` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "games" ADD COLUMN     "created_by_id" UUID NOT NULL;
+
+-- CreateTable
+CREATE TABLE "users" (
+    "id" UUID NOT NULL,
+    "discord_id" TEXT NOT NULL,
+    "discord_name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "users_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "users_discord_id_key" ON "users"("discord_id");
+
+-- AddForeignKey
+ALTER TABLE "games" ADD CONSTRAINT "games_created_by_id_fkey" FOREIGN KEY ("created_by_id") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -14,13 +14,32 @@ datasource db {
 }
 
 model Game {
-  id         String   @id @default(uuid()) @db.Uuid
+  id String @id @default(uuid()) @db.Uuid
+
+  isFree     Boolean @default(false) @map("is_free")
   name       String
-  numPlayers Int      @map("num_players")
-  released   Boolean  @default(true)
-  isFree     Boolean  @default(false) @map("is_free")
-  createdAt  DateTime @default(now()) @map("created_at")
-  updatedAt  DateTime @updatedAt @map("updated_at")
+  numPlayers Int     @map("num_players")
+  released   Boolean @default(true)
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  createdById String @map("created_by_id") @db.Uuid
+  createdBy   User   @relation(fields: [createdById], references: [id])
 
   @@map("games")
+}
+
+model User {
+  id String @id @default(uuid()) @db.Uuid
+
+  discordId   String @unique @map("discord_id")
+  discordName String @map("discord_name")
+
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  Game Game[]
+
+  @@map("users")
 }

--- a/src/commands/addGame.ts
+++ b/src/commands/addGame.ts
@@ -21,7 +21,13 @@ export const addGame: Command = {
       return;
     };
 
-    await prisma.game.create({ data: { name, numPlayers } });
+    const user = await prisma.user.findUnique({ where: { discordId: interaction.user.id } });
+    if (!user) {
+      await interaction.reply("Failed to find user. This is a bug.");
+      return;
+    };
+
+    await prisma.game.create({ data: { name, numPlayers, createdById: user.id } });
     await interaction.reply(`${name} added!`);
   },
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ import { ChatInputCommandInteraction, Client, Events, GatewayIntentBits, REST, R
 import { addGame } from "./commands/addGame";
 import { listGames } from "./commands/listGames";
 
+import { registerUser } from "./util/registerUser";
+
 export interface Command {
   builder: SlashCommandBuilder;
   execute: (interaction: ChatInputCommandInteraction) => Promise<void>;
@@ -28,6 +30,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
   const command = interaction.commandName;
   switch (command) {
     case "addgame":
+      await registerUser(interaction.user.id, interaction.user.displayName);
       await addGame.execute(interaction);
       break;
     case "listgames":
@@ -40,6 +43,7 @@ client.on(Events.InteractionCreate, async (interaction) => {
 
 client.login(process.env.DISCORD_TOKEN);
 
+// Register all application commands
 const rest = new REST().setToken(process.env.DISCORD_TOKEN!);
 (async () => {
   try {

--- a/src/util/registerUser.ts
+++ b/src/util/registerUser.ts
@@ -1,0 +1,8 @@
+import { prisma } from "..";
+
+export const registerUser = async (discordId: string, discordName: string) => {
+  const existingUser = await prisma.user.findUnique({ where: { discordId } });
+  if (existingUser) return;
+
+  await prisma.user.create({ data: { discordId, discordName } });
+};


### PR DESCRIPTION
Adds Discord user ID and display name (server name) to the database to record who creates games using the `addName` command. This will also be used for rating all games.