### PR TITLE
Fix sort imports linting rule not working

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -14,4 +14,5 @@ export default [
     semi: true,
     braceStyle: "1tbs",
   }),
+  { rules: { "sort-imports": ["error", { allowSeparatedGroups: true }] } },
 ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ if (process.env.NODE_ENV === "development") {
   require("dotenv").config();
 }
 
-import { PrismaClient } from "@prisma/client";
 import { ChatInputCommandInteraction, Client, Events, GatewayIntentBits, REST, Routes, SlashCommandBuilder } from "discord.js";
+import { PrismaClient } from "@prisma/client";
 
 import { commandMap } from "./commands";
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,7 +1,7 @@
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
+import nodeExternals from "webpack-node-externals";
 import { resolve } from "path";
 import webpack from "webpack";
-import nodeExternals from "webpack-node-externals";
 
 const config: webpack.Configuration = {
   devtool: "source-map",


### PR DESCRIPTION
Fixes `sort-imports` ESLint rule not working. This should be enabled by default; not sure exactly what is preventing this from running normally. Possibly this is being disabled in one of the recommended plugin configurations. More investigation could be needed later, but this works fine for now.