### PR TITLE
Remove discordName from users as it is unused

### DIFF
--- a/prisma/migrations/20240908051833_remove_discord_name_from_users/migration.sql
+++ b/prisma/migrations/20240908051833_remove_discord_name_from_users/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `discord_name` on the `users` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "users" DROP COLUMN "discord_name";

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,8 +55,7 @@ model Rating {
 model User {
   id String @id @default(uuid()) @db.Uuid
 
-  discordId   String @unique @map("discord_id")
-  discordName String @map("discord_name")
+  discordId String @unique @map("discord_id")
 
   createdAt DateTime @default(now()) @map("created_at")
   updatedAt DateTime @updatedAt @map("updated_at")

--- a/src/util/registerUser.ts
+++ b/src/util/registerUser.ts
@@ -6,5 +6,5 @@ export const registerUser = async (user: User) => {
   const existingUser = await prisma.user.findUnique({ where: { discordId: user.id } });
   if (existingUser) return existingUser;
 
-  return await prisma.user.create({ data: { discordId: user.id, discordName: user.displayName } });
+  return await prisma.user.create({ data: { discordId: user.id } });
 };


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

Removes `users.discord_name` database column as it's unused. We do not need to store user names as giving the Discord ID in the format `<@1234567890>` in any response will auto-correct to the user's current display name in the server they are being mentioned from.
