### PR TITLE
Add guildId to games to separate servers

### DIFF
--- a/prisma/migrations/20240908071437_add_guild_id_to_games/migration.sql
+++ b/prisma/migrations/20240908071437_add_guild_id_to_games/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `guild_id` to the `games` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "games" ADD COLUMN     "guild_id" TEXT NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,6 +17,7 @@ model Game {
   id String @id @default(uuid()) @db.Uuid
 
   isFree     Boolean @default(false) @map("is_free")
+  guildId    String  @map("guild_id")
   name       String
   numPlayers Int     @map("num_players")
   released   Boolean @default(true)

--- a/src/commands/addGame.ts
+++ b/src/commands/addGame.ts
@@ -9,6 +9,7 @@ interface GameData {
   description?: string;
   isFree?: boolean;
   gameURL?: string;
+  guildId: string;
   name: string;
   numPlayers: number;
   bannerImageURL?: string;
@@ -51,9 +52,15 @@ export const addGame: Command = {
     // Ensure required options are provided. This should never happen.
     if (!name || !numPlayers) return;
 
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply("This command can only be used in a server.");
+      return;
+    }
+
     const user = await registerUser(interaction.user);
 
-    const gameData: GameData = { createdById: user.id, name, numPlayers };
+    const gameData: GameData = { createdById: user.id, guildId, name, numPlayers };
 
     const url = interaction.options.getString("url");
     if (url) {

--- a/src/commands/listGames.ts
+++ b/src/commands/listGames.ts
@@ -7,7 +7,13 @@ const builder = new SlashCommandBuilder().setName("listgames").setDescription("L
 export const listGames: Command = {
   builder,
   execute: async (interaction) => {
-    const games = await prisma.game.findMany();
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply("This command can only be used in a server.");
+      return;
+    }
+
+    const games = await prisma.game.findMany({ where: { guildId } });
 
     const reply = `**Game List:**\n${games.map(game => `${game.name} - ${game.numPlayers} players`).join("\n")}`;
     await interaction.reply(reply);

--- a/src/commands/rateGames.ts
+++ b/src/commands/rateGames.ts
@@ -26,8 +26,15 @@ const builder = new SlashCommandBuilder().setName("rategames").setDescription("R
 export const rateGames: Command = {
   builder,
   execute: async (interaction) => {
+    const guildId = interaction.guildId;
+    if (!guildId) {
+      await interaction.reply("This command can only be used in a server.");
+      return;
+    }
+
     const user = await registerUser(interaction.user);
-    const games = await prisma.game.findMany({ where: { ratings: { none: { userId: user.id } } } });
+
+    const games = await prisma.game.findMany({ where: { guildId, ratings: { none: { userId: user.id } } } });
 
     const buttonOne = new ButtonBuilder().setCustomId("1").setLabel("1").setStyle(ButtonStyle.Danger);
     const buttonTwo = new ButtonBuilder().setCustomId("2").setLabel("2").setStyle(ButtonStyle.Secondary);


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

Adds `games.guild_id` support to distinguish which server games and ratings are created for. Users will need to re-upload and re-rate games in new servers. In the future we can smooth this process by cross server autocomplete or suggestions.
