### PR TITLE
Fix default DB values for primary IDs and updated_at

### DIFF
--- a/prisma/migrations/20250417080830_fix_id_and_updated_at_default_values/migration.sql
+++ b/prisma/migrations/20250417080830_fix_id_and_updated_at_default_values/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "games" ALTER COLUMN "id" SET DEFAULT gen_random_uuid(),
+ALTER COLUMN "updated_at" SET DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "ratings" ALTER COLUMN "id" SET DEFAULT gen_random_uuid();
+
+-- AlterTable
+ALTER TABLE "users" ALTER COLUMN "id" SET DEFAULT gen_random_uuid(),
+ALTER COLUMN "updated_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -15,7 +15,7 @@ datasource db {
 }
 
 model Game {
-  id String @id @default(uuid()) @db.Uuid
+  id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
 
   free       Boolean @default(false)
   guildId    String  @map("guild_id")
@@ -30,7 +30,7 @@ model Game {
   thumbnailImageURL String? @map("thumbnail_image_url")
 
   createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   createdById String @map("created_by_id") @db.Uuid
   createdBy   User   @relation(fields: [createdById], references: [id])
@@ -41,7 +41,7 @@ model Game {
 }
 
 model Rating {
-  id String @id @default(uuid()) @db.Uuid
+  id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
 
   score Int
 
@@ -56,12 +56,12 @@ model Rating {
 }
 
 model User {
-  id String @id @default(uuid()) @db.Uuid
+  id String @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
 
   discordId String @unique @map("discord_id")
 
   createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
+  updatedAt DateTime @default(now()) @updatedAt @map("updated_at")
 
   games   Game[]
   ratings Rating[]


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

Turns out Prisma's built in functions `uuid()` and the `@updatedAt` decorator don't actually set database level defaults. This will now ensure event if Prisma is not the source of creating data we still receive the proper defaults in the database.
