### PR TITLE
Fix interaction listeners crashing for listGames and removeGame

### DIFF
--- a/src/commands/listGames.ts
+++ b/src/commands/listGames.ts
@@ -118,6 +118,7 @@ export const listGames: Command = {
         });
       } catch {
         await reply.edit({ content: "List timed out. Type `/listgames` again to restart.", components: [] });
+        break;
       }
     }
   },

--- a/src/commands/removeGame.ts
+++ b/src/commands/removeGame.ts
@@ -119,7 +119,7 @@ export const removeGame: Command = {
             }
 
             await removeChoice.update({ content, components: [], embeds: [] });
-            return;
+            break;
           }
 
           await removeChoice.update({ embeds: [gameEmbedBuilder(game)] });
@@ -129,7 +129,7 @@ export const removeGame: Command = {
             components: [],
             embeds: [],
           });
-          return;
+          break;
         }
       }
     }


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

Fixes the listener for `listGames` to not time out and crash the app. Additionally future proofs `removeGame` if any logic is added after the while loop.
