### PR TITLE
DRY up embed code and fix inconsistencies between them

### DIFF
--- a/src/commands/addGame.ts
+++ b/src/commands/addGame.ts
@@ -4,6 +4,7 @@ import { GamePlatform, Prisma } from "@prisma/client";
 
 import { Command, prisma, steam } from "..";
 
+import { gameDetailsEmbedBuilder } from "../util/embedTemplates";
 import { registerUser } from "../util/registerUser";
 
 interface SteamGameDetails {
@@ -129,17 +130,8 @@ export const addGame: Command = {
 
     await interaction.reply({
       embeds: [{
-        description: game.gameResource?.description ?? undefined,
-        fields: [
-          { inline: true, name: "Released", value: game.released ? "Yes" : "No" },
-          { inline: true, name: "Free?", value: game.free ? "Yes" : "No" },
-          { inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` },
-        ],
+        ...gameDetailsEmbedBuilder(game),
         footer: { text: "Game successfully added." },
-        image: game.gameResource?.bannerImageURL ? { url: game.gameResource?.bannerImageURL } : undefined,
-        title: game.name,
-        thumbnail: game.gameResource?.thumbnailImageURL ? { url: game.gameResource?.thumbnailImageURL } : undefined,
-        url: game.gameURL ?? undefined,
       }],
     });
   },

--- a/src/commands/rateGames.ts
+++ b/src/commands/rateGames.ts
@@ -1,5 +1,4 @@
 import {
-  APIEmbed,
   ButtonBuilder,
   ButtonStyle,
   ComponentType,
@@ -8,28 +7,10 @@ import {
   SlashCommandBuilder,
 } from "discord.js";
 
-import { Prisma } from "@prisma/client";
-
 import { Command, prisma } from "..";
 
+import { gameDetailsEmbedBuilder } from "../util/embedTemplates";
 import { registerUser } from "../util/registerUser";
-
-type GameWithGameResource = Prisma.GameGetPayload<{ include: { gameResource: true } }>;
-
-const gameEmbedBuilder = (game: GameWithGameResource): APIEmbed => {
-  return {
-    description: game.gameResource?.description ?? undefined,
-    fields: [
-      { inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` },
-      { inline: true, name: "Free?", value: game.free ? "Yes" : "No" },
-    ],
-    footer: { text: "Rate the game from 1 to 5." },
-    image: game.gameResource?.bannerImageURL ? { url: game.gameResource?.bannerImageURL } : undefined,
-    title: game.name,
-    thumbnail: game.gameResource?.thumbnailImageURL ? { url: game.gameResource?.thumbnailImageURL } : undefined,
-    url: game.gameURL ?? undefined,
-  };
-};
 
 const builder = new SlashCommandBuilder()
   .setName("rategames")
@@ -78,7 +59,10 @@ export const rateGames: Command = {
         components: [buttonOne, buttonTwo, buttonThree, buttonFour, buttonFive],
         type: ComponentType.ActionRow,
       }],
-      embeds: [gameEmbedBuilder(game)],
+      embeds: [{
+        ...gameDetailsEmbedBuilder(game),
+        footer: { text: "Rate the game from 1 to 5." },
+      }],
       flags: MessageFlags.Ephemeral,
     });
 
@@ -100,7 +84,12 @@ export const rateGames: Command = {
           break;
         }
 
-        await ratingChoice.update({ embeds: [gameEmbedBuilder(game)] });
+        await ratingChoice.update({
+          embeds: [{
+            ...gameDetailsEmbedBuilder(game),
+            footer: { text: "Rate the game from 1 to 5." },
+          }],
+        });
       } catch {
         await reply.edit({
           content: "Rating timed out. Type `/rategames` again to resume.",

--- a/src/commands/rateSingleGame.ts
+++ b/src/commands/rateSingleGame.ts
@@ -1,5 +1,4 @@
 import {
-  APIEmbed,
   ButtonBuilder,
   ButtonStyle,
   ComponentType,
@@ -8,31 +7,11 @@ import {
   SlashCommandBuilder,
 } from "discord.js";
 
-import { Prisma } from "@prisma/client";
-
 import { Command, prisma } from "..";
 
 import { gameAutocomplete } from "../util/gameAutocomplete";
+import { gameDetailsEmbedBuilder } from "../util/embedTemplates";
 import { registerUser } from "../util/registerUser";
-
-type GameWithGameResource = Prisma.GameGetPayload<{ include: { gameResource: true } }>;
-
-const gameEmbedBuilder = (game: GameWithGameResource): APIEmbed => {
-  return {
-    description: game.gameResource?.description ?? undefined,
-    fields: [
-      { inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` },
-      { inline: true, name: "Free?", value: game.free ? "Yes" : "No" },
-    ],
-    footer: { text: "Rate the game from 1 to 5." },
-    image: game.gameResource?.bannerImageURL ? { url: game.gameResource?.bannerImageURL } : undefined,
-    title: game.name,
-    thumbnail: game.gameResource?.thumbnailImageURL
-      ? { url: game.gameResource?.thumbnailImageURL }
-      : undefined,
-    url: game.gameURL ?? undefined,
-  };
-};
 
 const builder = new SlashCommandBuilder()
   .setName("ratesinglegame")
@@ -123,7 +102,10 @@ export const rateSingleGame: Command = {
           type: ComponentType.ActionRow,
         },
       ],
-      embeds: [gameEmbedBuilder(game)],
+      embeds: [{
+        ...gameDetailsEmbedBuilder(game),
+        footer: { text: "Rate the game from 1 to 5." },
+      }],
       flags: MessageFlags.Ephemeral,
     });
 

--- a/src/commands/removeGame.ts
+++ b/src/commands/removeGame.ts
@@ -1,5 +1,4 @@
 import {
-  APIEmbed,
   ButtonBuilder,
   ButtonStyle,
   ComponentType,
@@ -12,23 +11,9 @@ import { Game, Prisma } from "@prisma/client";
 
 import { Command, prisma } from "..";
 import { gameAutocomplete } from "../util/gameAutocomplete";
+import { gameDetailsEmbedBuilder } from "../util/embedTemplates";
 
 type GameWithGameResource = Prisma.GameGetPayload<{ include: { gameResource: true } }>;
-
-const gameEmbedBuilder = (game: GameWithGameResource): APIEmbed => {
-  return {
-    description: game.gameResource?.description ?? undefined,
-    fields: [
-      { inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` },
-      { inline: true, name: "Free?", value: game.free ? "Yes" : "No" },
-    ],
-    footer: { text: "Remove this game?" },
-    image: game.gameResource?.bannerImageURL ? { url: game.gameResource?.bannerImageURL } : undefined,
-    title: game.name,
-    thumbnail: game.gameResource?.thumbnailImageURL ? { url: game.gameResource?.thumbnailImageURL } : undefined,
-    url: game.gameURL ?? undefined,
-  };
-};
 
 const builder = new SlashCommandBuilder()
   .setName("removegame")
@@ -94,7 +79,10 @@ export const removeGame: Command = {
       const reply = await interaction.reply({
         components: [{ components: [buttonNo, buttonYes], type: ComponentType.ActionRow }],
         content: "Multiple games by that name found. Remove this game?",
-        embeds: [gameEmbedBuilder(game)],
+        embeds: [{
+          ...gameDetailsEmbedBuilder(game),
+          footer: { text: "Remove this game?" },
+        }],
         flags: MessageFlags.Ephemeral,
       });
 
@@ -122,7 +110,12 @@ export const removeGame: Command = {
             break;
           }
 
-          await removeChoice.update({ embeds: [gameEmbedBuilder(game)] });
+          await removeChoice.update({
+            embeds: [{
+              ...gameDetailsEmbedBuilder(game),
+              footer: { text: "Remove this game?" },
+            }],
+          });
         } catch {
           await reply.edit({
             content: "Removal timed out. Type `/removegame` again to resume.",

--- a/src/util/embedTemplates.ts
+++ b/src/util/embedTemplates.ts
@@ -1,0 +1,20 @@
+import { APIEmbed } from "discord.js";
+
+import { Prisma } from "@prisma/client";
+
+type GameWithGameResource = Prisma.GameGetPayload<{ include: { gameResource: true } }>;
+
+export const gameDetailsEmbedBuilder = (game: GameWithGameResource): APIEmbed => {
+  return {
+    description: game.gameResource?.description ?? undefined,
+    fields: [
+      { inline: true, name: "Released?", value: game.released ? "Yes" : "No" },
+      { inline: true, name: "Free?", value: game.free ? "Yes" : "No" },
+      { inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` },
+    ],
+    image: game.gameResource?.bannerImageURL ? { url: game.gameResource?.bannerImageURL } : undefined,
+    title: game.name,
+    thumbnail: game.gameResource?.thumbnailImageURL ? { url: game.gameResource?.thumbnailImageURL } : undefined,
+    url: game.gameURL ?? undefined,
+  };
+};


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

Cleans up a lot of the similar embeds in responses so they all return the same format with different footers. `/whatshouldweplay` has a custom embed still due to ratings being displayed.
