### PR TITLE
Add ignoremaxplayers option to whatshouldweplay to remove max player constraints

### DIFF
--- a/src/commands/whatShouldWePlay.ts
+++ b/src/commands/whatShouldWePlay.ts
@@ -13,10 +13,16 @@ builder.addStringOption(option =>
     .setRequired(true),
 );
 
+builder.addBooleanOption(option =>
+  option.setName("ignoremaxplayers")
+    .setDescription("Ignore max player constraints when searching for a game."),
+);
+
 export const whatShouldWePlay: Command = {
   builder,
   execute: async (interaction) => {
     const rawPlayers = interaction.options.getString("players");
+    const ignoreMaxPlayers = interaction.options.getBoolean("ignoremaxplayers");
     const matchedPlayers = rawPlayers?.match(/<@[^&]([^>]+)/g);
 
     if (!matchedPlayers) {
@@ -42,7 +48,7 @@ export const whatShouldWePlay: Command = {
       take: 1,
       where: {
         game: {
-          maxPlayers: { gte: matchedPlayers.length },
+          maxPlayers: ignoreMaxPlayers ? undefined : { gte: matchedPlayers.length },
           minPlayers: { lte: matchedPlayers.length },
           released: true,
         },


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

When given `ignoremaxplayers` the `/whatshouldweplay` command will now ignore max player constraints when searching for games.
