### PR TITLE
Truncate long ratings to 2 decimal precision

### DIFF
--- a/src/commands/listGames.ts
+++ b/src/commands/listGames.ts
@@ -26,7 +26,7 @@ const gameEmbedBuilder = async (game: getGamesByAvgRating.Result): Promise<APIEm
       {
         inline: true,
         name: "Rating (Average)",
-        value: game.avg_score?.toString() || "No ratings yet",
+        value: game.avg_score?.toFixed(2) || "No ratings yet",
       },
       { inline: true, name: "Players", value: `${game.min_players} - ${game.max_players}` },
     ],

--- a/src/commands/whatShouldWePlay.ts
+++ b/src/commands/whatShouldWePlay.ts
@@ -84,7 +84,7 @@ export const whatShouldWePlay: Command = {
 
     const fields: APIEmbedField[] = [];
     if (game.gameURL) fields.push({ name: "URL:", value: game.gameURL });
-    fields.push({ inline: true, name: "Rating (Average)", value: totalRatings[0]._avg.score?.toString() });
+    fields.push({ inline: true, name: "Rating (Average)", value: totalRatings[0]._avg.score?.toFixed(2) });
     fields.push({ inline: true, name: "Free?", value: game.free ? "Yes" : "No" });
     fields.push({ inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` });
 


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

When there are decimals representing say 2 + 1/3 as a score, the embed looks messy with many repeating numbers. we don't need a super accurate score to display and can truncate to 2 precision.
