### PR TITLE
Add current rating to rate command embeds

### DIFF
--- a/src/commands/addGame.ts
+++ b/src/commands/addGame.ts
@@ -129,10 +129,7 @@ export const addGame: Command = {
     const game = await prisma.game.create({ data: gameData, include: { gameResource: true } });
 
     await interaction.reply({
-      embeds: [{
-        ...gameDetailsEmbedBuilder(game),
-        footer: { text: "Game successfully added." },
-      }],
+      embeds: [gameDetailsEmbedBuilder(game, "Game successfully added.")],
     });
   },
 };

--- a/src/commands/rateGames.ts
+++ b/src/commands/rateGames.ts
@@ -9,7 +9,7 @@ import {
 
 import { Command, prisma } from "..";
 
-import { gameDetailsEmbedBuilder } from "../util/embedTemplates";
+import { gameRatingEmbedBuilder } from "../util/embedTemplates";
 import { registerUser } from "../util/registerUser";
 
 const builder = new SlashCommandBuilder()
@@ -39,7 +39,16 @@ export const rateGames: Command = {
 
     const rateAll = interaction.options.getBoolean("all") ?? false;
     const gameWhere = rateAll ? { guildId } : { guildId, ratings: { none: { userId: user.id } } };
-    const games = await prisma.game.findMany({ include: { gameResource: true }, where: gameWhere });
+    const games = await prisma.game.findMany({
+      include: {
+        gameResource: true,
+        ratings: {
+          select: { score: true },
+          where: { user: { id: user.id } },
+        },
+      },
+      where: gameWhere,
+    });
 
     const buttonOne = new ButtonBuilder().setCustomId("1").setLabel("1").setStyle(ButtonStyle.Danger);
     const buttonTwo = new ButtonBuilder().setCustomId("2").setLabel("2").setStyle(ButtonStyle.Secondary);
@@ -59,10 +68,7 @@ export const rateGames: Command = {
         components: [buttonOne, buttonTwo, buttonThree, buttonFour, buttonFive],
         type: ComponentType.ActionRow,
       }],
-      embeds: [{
-        ...gameDetailsEmbedBuilder(game),
-        footer: { text: "Rate the game from 1 to 5." },
-      }],
+      embeds: [gameRatingEmbedBuilder(game, game.ratings[0])],
       flags: MessageFlags.Ephemeral,
     });
 
@@ -84,12 +90,7 @@ export const rateGames: Command = {
           break;
         }
 
-        await ratingChoice.update({
-          embeds: [{
-            ...gameDetailsEmbedBuilder(game),
-            footer: { text: "Rate the game from 1 to 5." },
-          }],
-        });
+        await ratingChoice.update({ embeds: [gameRatingEmbedBuilder(game, game.ratings[0])] });
       } catch {
         await reply.edit({
           content: "Rating timed out. Type `/rategames` again to resume.",

--- a/src/commands/rateSingleGame.ts
+++ b/src/commands/rateSingleGame.ts
@@ -10,7 +10,7 @@ import {
 import { Command, prisma } from "..";
 
 import { gameAutocomplete } from "../util/gameAutocomplete";
-import { gameDetailsEmbedBuilder } from "../util/embedTemplates";
+import { gameRatingEmbedBuilder } from "../util/embedTemplates";
 import { registerUser } from "../util/registerUser";
 
 const builder = new SlashCommandBuilder()
@@ -51,7 +51,7 @@ export const rateSingleGame: Command = {
           gameResource: true,
           ratings: {
             select: { score: true },
-            where: { user: { discordId: user.id } },
+            where: { user: { id: user.id } },
           },
         },
       });
@@ -102,10 +102,7 @@ export const rateSingleGame: Command = {
           type: ComponentType.ActionRow,
         },
       ],
-      embeds: [{
-        ...gameDetailsEmbedBuilder(game),
-        footer: { text: "Rate the game from 1 to 5." },
-      }],
+      embeds: [gameRatingEmbedBuilder(game, game.ratings[0])],
       flags: MessageFlags.Ephemeral,
     });
 
@@ -115,21 +112,21 @@ export const rateSingleGame: Command = {
         time: 30000,
       });
 
-      await prisma.rating.upsert({
+      const rating = await prisma.rating.upsert({
         create: {
           gameId: game.id,
           score: parseInt(ratingChoice.customId),
           userId: user.id,
         },
+        select: { score: true },
         update: { score: parseInt(ratingChoice.customId) },
         where: { gameId_userId: { gameId: game.id, userId: user.id } },
       });
 
       if (ratingChoice.customId != null) {
         await ratingChoice.update({
-          content: "Successfully rated game!",
           components: [],
-          embeds: [],
+          embeds: [gameRatingEmbedBuilder(game, rating, "Successfully rated game!")],
         });
       }
     } catch {

--- a/src/commands/removeGame.ts
+++ b/src/commands/removeGame.ts
@@ -79,10 +79,7 @@ export const removeGame: Command = {
       const reply = await interaction.reply({
         components: [{ components: [buttonNo, buttonYes], type: ComponentType.ActionRow }],
         content: "Multiple games by that name found. Remove this game?",
-        embeds: [{
-          ...gameDetailsEmbedBuilder(game),
-          footer: { text: "Remove this game?" },
-        }],
+        embeds: [gameDetailsEmbedBuilder(game, "Remove this game?")],
         flags: MessageFlags.Ephemeral,
       });
 
@@ -111,10 +108,7 @@ export const removeGame: Command = {
           }
 
           await removeChoice.update({
-            embeds: [{
-              ...gameDetailsEmbedBuilder(game),
-              footer: { text: "Remove this game?" },
-            }],
+            embeds: [gameDetailsEmbedBuilder(game, "Remove this game?")],
           });
         } catch {
           await reply.edit({

--- a/src/util/embedTemplates.ts
+++ b/src/util/embedTemplates.ts
@@ -3,8 +3,9 @@ import { APIEmbed } from "discord.js";
 import { Prisma } from "@prisma/client";
 
 type GameWithGameResource = Prisma.GameGetPayload<{ include: { gameResource: true } }>;
+type RatingScore = Prisma.RatingGetPayload<{ select: { score: true } }>;
 
-export const gameDetailsEmbedBuilder = (game: GameWithGameResource): APIEmbed => {
+export const gameDetailsEmbedBuilder = (game: GameWithGameResource, footerText?: string): APIEmbed => {
   return {
     description: game.gameResource?.description ?? undefined,
     fields: [
@@ -12,9 +13,20 @@ export const gameDetailsEmbedBuilder = (game: GameWithGameResource): APIEmbed =>
       { inline: true, name: "Free?", value: game.free ? "Yes" : "No" },
       { inline: true, name: "Players", value: `${game.minPlayers} - ${game.maxPlayers}` },
     ],
+    footer: footerText ? { text: footerText } : undefined,
     image: game.gameResource?.bannerImageURL ? { url: game.gameResource?.bannerImageURL } : undefined,
     title: game.name,
     thumbnail: game.gameResource?.thumbnailImageURL ? { url: game.gameResource?.thumbnailImageURL } : undefined,
     url: game.gameURL ?? undefined,
   };
+};
+
+export const gameRatingEmbedBuilder = (
+  game: GameWithGameResource,
+  rating?: RatingScore,
+  footerText: string = "Rate the game from 1 to 5.",
+) => {
+  const embed = gameDetailsEmbedBuilder(game, footerText);
+  embed.fields?.push({ name: "Your Rating", value: rating?.score.toString() ?? "Not rated" });
+  return embed;
 };


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

Reworks embeds to more easily add footers and additional fields to similar embeds. Also adds the user's current rating to embeds on `ratesinglegame` and `rategames` command.
