### PR TITLE
Fix whatshouldweplay extra games counts missing guild ID scope

### DIFF
--- a/apps/discord/src/commands/whatShouldWePlay.ts
+++ b/apps/discord/src/commands/whatShouldWePlay.ts
@@ -110,8 +110,12 @@ export const whatShouldWePlay: Command = {
     });
     fields.push({ name: "Your Ratings:", value: ratingValues });
 
-    const numSmallerGames = await prisma.game.count({ where: { maxPlayers: { lt: matchedPlayers.length } } });
-    const numLargerGames = await prisma.game.count({ where: { minPlayers: { gt: matchedPlayers.length } } });
+    const numSmallerGames = await prisma.game.count({
+      where: { guildId: guild.id, maxPlayers: { lt: matchedPlayers.length } },
+    });
+    const numLargerGames = await prisma.game.count({
+      where: { guildId: guild.id, minPlayers: { gt: matchedPlayers.length } },
+    });
     let footerText: string | undefined = undefined;
     if (numSmallerGames > 0) {
       footerText = `There are ${numSmallerGames} game${numSmallerGames === 1 ? "" : "s"} that support fewer players.`;


### PR DESCRIPTION
<!--
Please review and fill out the below template as applicable.
-->

# WSWP

## Checklist

<!-- Ensure all steps below are complete before merging. -->

- [x] PR name should be a concise description of the change
  - Example: "Add coolCommand to return cool things"
  - Example: "Fix the broken output of anotherCommand to not throw an error"
- [x] Add one applicable changelog label to the PR
  - Should match the change type: (bug, documentation, enhancement, task)
  - This enables our changelog generator to accurately tag this change
- [x] Add "migrations" label to the PR if migration files are present
  - Migrations need to be thoroughly reviewed before ran to prevent production issues
  - This also alerts the person deploying to run the migration script after deployment

## Description

<!--
Write a short description detailing how this change accomplishes the feature change or fixes the bug.
-->

The counts for "X games with fewer / more players found" were not correctly scoping their count to games registered to the current guild (Discord server). Games from other servers were counted in the totals.
